### PR TITLE
githubのsshを使わないgitプロトコル廃止に伴い、httpsを利用するよう変更

### DIFF
--- a/ruby-setup.sh
+++ b/ruby-setup.sh
@@ -20,8 +20,8 @@ fi
 
 # install rbenv
 if ! command -v rbenv &> /dev/null; then
-  git clone git://github.com/sstephenson/rbenv.git .rbenv
-  git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+  git clone https://github.com/sstephenson/rbenv.git .rbenv
+  git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
   echo 'export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile
   echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
   source ~/.bash_profile

--- a/update-ruby.sh
+++ b/update-ruby.sh
@@ -12,8 +12,8 @@ fi
 
 # install rbenv
 if ! command -v rbenv &> /dev/null; then
-  git clone git://github.com/sstephenson/rbenv.git .rbenv
-  git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+  git clone https://github.com/sstephenson/rbenv.git .rbenv
+  git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
   echo 'export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile
   echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
   source ~/.bash_profile


### PR DESCRIPTION
[https://github.blog/2021-09-01-improving-git-protocol-security-github/#:~:text=Only%20users%20connecting%20v[…]0for%20the%20details%20and%20timeline](https://github.blog/2021-09-01-improving-git-protocol-security-github/#:~:text=Only%20users%20connecting%20via%20SSH%20or%20git%3A//%20are%20affected.%20If%20your%20Git%20remotes%20start%20with%20https%3A//%2C%20nothing%20in%20this%20post%20will%20affect%20you.%20If%20you%E2%80%99re%20an%20SSH%20user%2C%20read%20on%20for%20the%20details%20and%20timeline)